### PR TITLE
Only save max of 30 notifications per user

### DIFF
--- a/helpers/notificationManager.js
+++ b/helpers/notificationManager.js
@@ -23,7 +23,10 @@ module.exports = {
   	const notification = new Notification(notificationData);
   	notification.save().then(notif => {
   		user.notifications.unshift(notif);
-  		user.save().then(user => {console.log('notifCreated')})
+      const removed = user.notifications.splice(30);
+  		user.save().then(user => {
+        Notification.deleteMany({ _id: { $in: removed } });
+      })
   		.catch(err => console.error(err));
   	})
   	.catch(err => console.error(err));


### PR DESCRIPTION
There was a bug where if a user had too many notifications (~800) they couldn't log in, this limits notifications to 30 per user in order to fix this issue. Will also delete old notifications from the db to free up some space to help stay within the free 500mb limit.

Tested locally & works.