### PR TITLE
Added liking endpoint

### DIFF
--- a/controllers/postController.js
+++ b/controllers/postController.js
@@ -87,6 +87,20 @@ router.put('/:id', verifyToken, (req, res) => {
 });
 
 /**
+ * Like a post
+ */
+router.post('/:pid/like', verifyToken, (req, res) => {
+  Post.likePost(req.params.pid, req.user._id, req.body.isLiked)
+  .then(post => {
+    res.json(post);
+  })
+  .catch(err => {
+    var errRes = classifyError(err);
+    res.status(errRes.status).json(errRes.message);
+  });
+});
+
+/**
  * Delete a post
  */
 router.delete('/:id', verifyToken, (req, res) => {

--- a/controllers/postController.js
+++ b/controllers/postController.js
@@ -90,7 +90,7 @@ router.put('/:id', verifyToken, (req, res) => {
  * Like a post
  */
 router.post('/:pid/like', verifyToken, (req, res) => {
-  Post.likePost(req.params.pid, req.user._id, req.body.isLiked)
+  Post.likePost(req.params.pid, req.user._id, req.body.addLike)
   .then(post => {
     res.json(post);
   })

--- a/models/Posts.js
+++ b/models/Posts.js
@@ -206,16 +206,16 @@ PostSchema.statics.likePost = function (id, user, isLiked) {
     this.findById(id).then(post => {
       if (post && post.usersLiked) {
         if(isLiked){
-          if(post.usersLiked.includes(user)){
+          if(post.usersLiked.some(e => e == user)){
             reject("Already liked");
           }else{
             post.usersLiked.push(user);
-            post.likes++;
+            post.likes = post.usersLiked.length;
           }
         }else{
-          if(post.usersLiked.includes(user)){
-            post.usersLiked.splice(post.usersLiked.indexOf(user), 1);
-            post.likes--;
+          if(post.usersLiked.some(e => e == user)){
+            post.usersLiked = post.usersLiked.filter(u => u != user)
+            post.likes = post.usersLiked.length;
           }else{
             reject("Already not liked")
           }

--- a/models/Posts.js
+++ b/models/Posts.js
@@ -199,21 +199,23 @@ PostSchema.statics.updatePost = function (id, postData) {
   });
 }
 
-PostSchema.statics.likePost = function (id, user, isLiked) {
+PostSchema.statics.likePost = function (id, user, addLike) {
   id = ObjectId(id);
 
   return new Promise((resolve, reject) => {
     this.findById(id).then(post => {
       if (post && post.usersLiked) {
-        if(isLiked){
+        if(addLike){
           if(post.usersLiked.some(e => e == user)){
             reject("Already liked");
           }else{
+            //add user to list
             post.usersLiked.push(user);
             post.likes = post.usersLiked.length;
           }
         }else{
           if(post.usersLiked.some(e => e == user)){
+            //remove every instance of user from list
             post.usersLiked = post.usersLiked.filter(u => u != user)
             post.likes = post.usersLiked.length;
           }else{

--- a/models/Posts.js
+++ b/models/Posts.js
@@ -199,6 +199,41 @@ PostSchema.statics.updatePost = function (id, postData) {
   });
 }
 
+PostSchema.statics.likePost = function (id, user, isLiked) {
+  id = ObjectId(id);
+
+  return new Promise((resolve, reject) => {
+    this.findById(id).then(post => {
+      if (post && post.usersLiked) {
+        if(isLiked){
+          if(post.usersLiked.includes(user)){
+            reject("Already liked");
+          }else{
+            post.usersLiked.push(user);
+            post.likes++;
+          }
+        }else{
+          if(post.usersLiked.includes(user)){
+            post.usersLiked.splice(post.usersLiked.indexOf(user), 1);
+            post.likes--;
+          }else{
+            reject("Already not liked")
+          }
+        }
+        post.save().then(post => {
+          resolve(post);
+        })
+          .catch(err => {
+            reject(err);
+          });
+      }
+      else {
+        reject('Couldn\'t find a post with that ID');
+      }
+    });
+  });
+}
+
 PostSchema.statics.delete = function (id) {
   id = ObjectId(id);
 


### PR DESCRIPTION
Adding an end point for liking a post. Currently this is done using updatePost endpoint, which is not very secure because then any user can edit any part of the post. There will be a corresponding change to the client sides, but it will be dependent on this PR: https://github.com/CGUC/skybunk-mobile/pull/143. This PR will be merged before PR #72, since that PR needs these updates to function properly.