### PR TITLE
Changed user.info to not be a schema

### DIFF
--- a/models/User.js
+++ b/models/User.js
@@ -31,7 +31,7 @@ const UserSchema = new Schema({
 	role: [{
 		type: String,
 	}],
-	info: new Schema({
+	info: {
 		program: {
 			type: String
 		},
@@ -47,7 +47,7 @@ const UserSchema = new Schema({
 		phone: {
 			type: String
 		}
-	}),
+	},
 	profilePicture: {
 		type: Schema.Types.ObjectId,
 		ref: 'ProfilePicture',


### PR DESCRIPTION
There is a weird bug where if a user updates only one field of their info, then the rest of the fields will get deleted. This is because Mongoose is doing weird things when trying to update a subdocument (this.info=updatedUserData.info in User.js). Making it a dictionary should solve this, and since its a 1 to 1 relation a separate schema is not needed.