### PR TITLE
Change login error format to match that of client

### DIFF
--- a/controllers/userController.js
+++ b/controllers/userController.js
@@ -161,7 +161,11 @@ router.post('/login', (req, res) => {
       res.json({ token });
     });
   }).catch((err) => {
-    res.json({ err });
+    res.json({
+      err: {
+        message: err.message,
+      },
+    });
   });
 });
 


### PR DESCRIPTION
This refers to the errors such as "Username not found" or "Incorrect password" when attempting to log in

The linting commit changed the way this error was formatted so it wasn't compatible with the client.
This changes it back, however we should probably standardise the format of our error handling since it's kind of a mess as is. 