### PR TITLE
Minor server side poll functionality fix

### DIFF
--- a/models/Media/Poll.js
+++ b/models/Media/Poll.js
@@ -66,14 +66,15 @@ const PollSchema = new Schema({
 PollSchema.statics.create = function (pollData, userId) {
   return new Promise((resolve, reject) => {
     const options = pollData.options.map(option => ({
-      text: option,
-      usersVoted: [],
+      text: option.text,
+      usersVoted: option.usersVoted || [],
       creator: ObjectId(userId),
     }));
 
     const newPoll = new this({
       title: pollData.title,
       multiSelect: pollData.multiSelect,
+      open: !!pollData.open,
       options,
     });
 

--- a/test/models/poll.test.js
+++ b/test/models/poll.test.js
@@ -113,15 +113,23 @@ describe('Polls', () => {
       const pollData = {
         title: 'What is your favourite colour',
         multiSelect: false,
-        options: ['red', 'blue', 'yellow'],
+        options: [{
+          text: 'red',
+        }, {
+          text: 'blue',
+          usersVoted: [UserFactory.fred._id],
+        }, {
+          text: 'yellow',
+        }],
       };
 
       Poll.create(pollData, UserFactory.fred._id.toString()).then((result) => {
         expect(result.title).to.equal(pollData.title);
         expect(result.multiSelect).to.equal(pollData.multiSelect);
-        expect(result.options[0].text).to.equal(pollData.options[0]);
-        expect(result.options[1].text).to.equal(pollData.options[1]);
-        expect(result.options[2].text).to.equal(pollData.options[2]);
+        expect(result.options[0].text).to.equal(pollData.options[0].text);
+        expect(result.options[1].text).to.equal(pollData.options[1].text);
+        expect(result.options[2].text).to.equal(pollData.options[2].text);
+        expect(result.options[1].usersVoted[0]).to.equal(UserFactory.fred._id);
         done();
       });
     });


### PR DESCRIPTION
3-lines change to make mobile side functionality work better: accept poll data with options which already have (a) voter(s), and correctly update open value