### PR TITLE
Add admin ednpoint for inviting users via email

### DIFF
--- a/controllers/adminController.js
+++ b/controllers/adminController.js
@@ -1,13 +1,21 @@
 const express = require('express');
 
 const router = express.Router();
-
 const adminHelper = require('../helpers/adminHelper');
+const { verifyToken, verifyAdmin } = require('../helpers/authorization');
 
-
-router.post('/tickets', (req, res) => {
+router.post('/tickets', verifyToken, verifyAdmin, (req, res) => {
   adminHelper.generateTickets(req.body.count).then((tickets) => {
     res.json(tickets);
+  }).catch((err) => {
+    console.error(err);
+    res.status(500).send('error');
+  });
+});
+
+router.post('/inviteUsers', verifyToken, verifyAdmin, (req, res) => {
+  adminHelper.inviteUsers(req.body.users).then((status) => {
+    res.json(status);
   }).catch((err) => {
     console.error(err);
     res.status(500).send('error');

--- a/helpers/adminHelper.js
+++ b/helpers/adminHelper.js
@@ -1,11 +1,45 @@
+require('../models/GoldenTicket');
 const mongoose = require('mongoose');
+const nodemailer = require('nodemailer');
 const fetch = require('node-fetch');
 const { authServerAddress } = require('../config/options');
 const { accessKey } = require('../config/secrets');
 
-require('../models/GoldenTicket');
-
 const GoldenTicket = mongoose.model('GoldenTicket');
+
+function dispatchEmail(user, ticket, transporter) {
+  const mailOptions = {
+    from: process.env.EMAIL_ADDRESS,
+    to: user.email,
+    subject: 'Welcome to Skybunk!',
+    html: `
+      <p>Hi ${user.name},</p>
+      <h2>You have been invited to Skybunk!</h2>
+      <p>Skybunk is a social platform in order to facilitate community within University Residences. You can meet others in your residence,
+      stay on top of important happenings, and organize events of your own.</p>
+      <p>Please register using the following golden ticket: ${ticket}</p>
+      <h4>Download the app!</h4>
+      <p>Android: <a href="https://play.google.com/store/apps/details?id=com.grebel.skybunk&hl=en_CA">https://play.google.com/store/apps/details?id=com.grebel.skybunk&hl=en_CA</a><br></br>
+      iOS: <a href="https://apps.apple.com/ca/app/skybunk/id1411727712">https://apps.apple.com/ca/app/skybunk/id1411727712</a></p>
+    `,
+  };
+
+  return new Promise((resolve) => {
+    transporter.sendMail(mailOptions, (err) => {
+      const response = {
+        errors: [],
+        successes: 0,
+      };
+
+      if (err) {
+        response.errors.push({ user: user.email, err });
+      } else {
+        response.successes = 1;
+      }
+      resolve(response);
+    });
+  });
+}
 
 module.exports.generateTickets = count => fetch(`${authServerAddress}/servers/${process.env.SERVER_ID}/tickets`, {
   method: 'POST',
@@ -17,7 +51,36 @@ module.exports.generateTickets = count => fetch(`${authServerAddress}/servers/${
   body: JSON.stringify({ count }),
 }).then(response => response.json()).then(async (jsonResponse) => {
   await GoldenTicket.insertMany(jsonResponse.map(ticketNumber => ({ ticketNumber })));
+
   return jsonResponse;
 }).catch((err) => {
   console.error(err);
 });
+
+module.exports.inviteUsers = async (users) => {
+  let tickets = [];
+  try {
+    tickets = await module.exports.generateTickets(users.length);
+  } catch (e) {
+    return { errors: { err: 'Could not generate golden tickets.' } };
+  }
+
+  const transporter = nodemailer.createTransport({
+    service: 'gmail',
+    auth: {
+      user: process.env.EMAIL_ADDRESS,
+      pass: process.env.EMAIL_PASSWORD,
+    },
+  });
+
+  const promises = [];
+  users.forEach((u, i) => {
+    promises.push(dispatchEmail(u, tickets[i], transporter));
+  });
+
+  return Promise.all(promises).then(values => values.reduce((acc, val) => {
+    acc.errors = [...acc.errors, ...val.errors];
+    acc.successes += val.successes;
+    return acc;
+  }, { errors: [], successes: 0 }));
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -3898,6 +3898,11 @@
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
       "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
     },
+    "nodemailer": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.3.0.tgz",
+      "integrity": "sha512-TEHBNBPHv7Ie/0o3HXnb7xrPSSQmH1dXwQKRaMKDBGt/ZN54lvDVujP6hKkO/vjkIYL9rK8kHSG11+G42Nhxuw=="
+    },
     "nodemon": {
       "version": "1.19.1",
       "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-1.19.1.tgz",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "mongoose-paginate": "^5.0.3",
     "multer": "^1.3.1",
     "node-fetch": "^2.3.0",
+    "nodemailer": "^6.3.0",
     "path": "^0.12.7",
     "sharp": "^0.22.1",
     "sinon-mongoose": "^2.2.1"


### PR DESCRIPTION
Adds an endpoint that does the following:

`POST ..../admin/inviteUsers`
- Takes `users` param in the body.
```
[{
    name: "Ryan",
    email: "myemail@gmail.com"
}, {
    name: "Another user",
    email: "anotherEmail@gmail.com"
}]
```
- Generates `users.length` golden tickets on the **auth server**
- Sends an email to each user, containing a valid golden ticket
- Returns a response which contains a list of errors (if any) and number of successful emails sent.

Requires a gmail email address with less secure apps enabled.
Testing via the heroku review app should have the appropriate environment variables.