### PR TITLE
Added password reset endpoints

### DIFF
--- a/config/options.js
+++ b/config/options.js
@@ -4,8 +4,27 @@ if (process.env.AUTH_SERVER_URI) {
   authServerAddress = process.env.AUTH_SERVER_URI;
 }
 
+let webmasterEmail = 'webmasters@grebelife.com';
+let skybunkEmail = {
+  user:"grebel_app@gmail.com",
+  pass:'1234'
+}
+
+if (process.env.SKYBUNK_EMAIL_ADDR && process.env.SKYBUNK_EMAIL_PASS ) {
+  skybunkEmail = {
+    user:process.env.SKYBUNK_EMAIL_ADDR,
+    pass:process.env.SKYBUNK_EMAIL_PASS
+  }
+}
+
+if (process.env.WEBMASTER_EMAIL) {
+  webmasterEmail = process.env.WEBMASTER_EMAIL;
+}
+
 module.exports = {
   postCharacterLimit: 1000,
   commentCharacterLimit: 500,
   authServerAddress,
+  webmasterEmail,
+  skybunkEmail,
 };

--- a/controllers/userController.js
+++ b/controllers/userController.js
@@ -37,21 +37,21 @@ router.post('/reset', (req, res) => {
   //query by name or by username
   if(body.username != undefined && body.username != ''){
     query = {username: body.username};
-  }else if(body.lastName != undefined && body.firstName !=undefined){
+  }else if(body.lastName != undefined && body.firstName !=undefined && body.lastName != '' && body.firstName !=''){
     query = {firstName: body.firstName, lastName: body.lastName};
   }else{
-    res.status(400);
+    res.status(400).json("No user found");
     return;
   }
 
   User.findOne(query).then((user) => {
     if(user == undefined){
-      res.status(400).json("no valid user found");
+      res.status(400).json("No user found");
       return;
     }
     if(user.info.email != undefined && user.info.email != '' && user.info.email.toLowerCase() != body.email.toLowerCase()){
       //given email does not match stored email, so return forbidden
-      res.status(403);
+      res.status(403).json("Given email is invalid");
       return;
     } else{
       //either given email matches, or no email is on file
@@ -64,6 +64,7 @@ router.post('/reset', (req, res) => {
       });
     }
   }).catch((err) => {
+    console.error(err);
     res.json(err);
   });
 });

--- a/controllers/userController.js
+++ b/controllers/userController.js
@@ -5,7 +5,7 @@ const mongoose = require('mongoose');
 const jwt = require('jsonwebtoken');
 const multer = require('multer');
 const { jwtSecret } = require('../config/secrets');
-const { verifyToken } = require('../helpers/authorization');
+const { verifyToken, verifyPasswordResetToken } = require('../helpers/authorization');
 // const setTimer = require('../helpers/jobScheduler');
 
 const upload = multer({ storage: multer.memoryStorage() });
@@ -24,6 +24,56 @@ router.get('/', verifyToken, (req, res) => {
 router.get('/user/:id', verifyToken, (req, res) => {
   User.findOne({ _id: req.params.id }).select('-password -notificationTokens -notifications').then((user) => {
     res.json(user);
+  }).catch((err) => {
+    res.json(err);
+  });
+});
+
+// Start password reset process by sending email
+router.post('/reset', (req, res) => {
+  var query;
+  const body = req.body;
+
+  //query by name or by username
+  if(body.username != undefined && body.username != ''){
+    query = {username: body.username};
+  }else if(body.lastName != undefined && body.firstName !=undefined){
+    query = {firstName: body.firstName, lastName: body.lastName};
+  }else{
+    res.status(400);
+    return;
+  }
+
+  User.findOne(query).then((user) => {
+    if(user == undefined){
+      res.status(400).json("no valid user found");
+      return;
+    }
+    if(user.info.email != undefined && user.info.email != '' && user.info.email.toLowerCase() != body.email.toLowerCase()){
+      //given email does not match stored email, so return forbidden
+      res.status(403);
+      return;
+    } else{
+      //either given email matches, or no email is on file
+      user.sendPasswordResetEmail(body.email).then((response) => {
+        res.json(response);
+      })
+      .catch((err) =>{
+        console.error(err)
+        res.status(400).json(err);
+      });
+    }
+  }).catch((err) => {
+    res.json(err);
+  });
+});
+
+//Reset password from reset password link
+router.post('/reset/:id/:token', verifyPasswordResetToken, (req, res) => {
+  const user = req.user;
+  console.log(req)
+  user.changePassword(req.body.password).then((password) => {
+    res.json(password);
   }).catch((err) => {
     res.json(err);
   });

--- a/helpers/authorization.js
+++ b/helpers/authorization.js
@@ -39,7 +39,9 @@ module.exports = {
     User.findById(req.params.id).then((user) => {
       if(user == undefined){
         res.status(400).json("No user found");
-      } else if(token !== user.resetPasswordToken){
+      } else if(req.body.username.toLowerCase() != user.username.toLowerCase()){
+        res.status(403).json("Invalid username");
+      }else if(token !== user.resetPasswordToken){
         res.status(403).json("Incorrect token");
       } else if(Date.now() > user.resetPasswordExpiration){
         res.status(403).json("Expired token");

--- a/helpers/authorization.js
+++ b/helpers/authorization.js
@@ -38,11 +38,11 @@ module.exports = {
     const token = req.params.token;
     User.findById(req.params.id).then((user) => {
       if(user == undefined){
-        res.sendStatus(400).json("No user found");
+        res.status(400).json("No user found");
       } else if(token !== user.resetPasswordToken){
-        res.sendStatus(403).json("Incorrect token");
+        res.status(403).json("Incorrect token");
       } else if(Date.now() > user.resetPasswordExpiration){
-        res.sendStatus(403).json("Expired token");
+        res.status(403).json("Expired token");
       }else{
         //success!
         req.user = user;

--- a/helpers/authorization.js
+++ b/helpers/authorization.js
@@ -1,5 +1,7 @@
 const jwt = require('jsonwebtoken');
 const { jwtSecret } = require('../config/secrets');
+const mongoose = require('mongoose');
+const User = mongoose.model('User');
 
 module.exports = {
   verifyToken(req, res, next) {
@@ -31,4 +33,23 @@ module.exports = {
       next();
     }
   },
+
+  verifyPasswordResetToken(req, res, next) {
+    const token = req.params.token;
+    User.findById(req.params.id).then((user) => {
+      if(user == undefined){
+        res.sendStatus(400).json("No user found");
+      } else if(token !== user.resetPasswordToken){
+        res.sendStatus(403).json("Incorrect token");
+      } else if(Date.now() > user.resetPasswordExpiration){
+        res.sendStatus(403).json("Expired token");
+      }else{
+        //success!
+        req.user = user;
+        next();
+      }
+    }).catch((err) => {
+      res.json(err);
+    });
+	},
 };

--- a/helpers/passwordReset.js
+++ b/helpers/passwordReset.js
@@ -1,0 +1,66 @@
+const nodemailer = require('nodemailer');
+const crypto = require('crypto');
+
+const config = require('../config/options');
+
+const url = 'https://www.skybunk.xyz';
+
+
+module.exports = {
+	sendPasswordResetEmail(user, email){
+		return new Promise((res, rej) => {
+			const token = crypto.randomBytes(20).toString('hex');
+
+			var mailOptions;
+			if(user.info.email == undefined || user.info.email == ''){ //send email to webmasters and tell them to verify the password reset was requested
+				mailOptions = {
+					to: config.webmasterEmail,
+					subject: `Skybunk Password Reset for ${user.firstName} ${user.lastName}`,
+					text:
+					`You are receiving this because ${user.firstName} ${user.lastName}  has requested the reset of the password for your Skybunk account. `
+					+ `They do not have a registered email address, so the password reset request must be manually verified.\n\n`
+					+ `Please manually verify ${user.firstName} requested this reset. If they did, forward this email to ${email}\n\n\n`
+					+ '-------------------------\n\n'
+					+ 'You are receiving this because you have requested the reset of the password for your Skybunk account.\n\n'
+					+ 'Please click on the following link, or paste this into your browser to complete the process within two days of receiving it:\n\n'
+					+ `${url}/users/reset/${user._id}/${token}\n\n`
+					+ `Username: ${user.username}\n\n`
+					+ 'If you did not request this, please ignore this email and your password will remain unchanged.\n',
+				};
+
+				user.resetPasswordExpiration = Date.now() + 48*60*60*1000; //48 hours from now
+			}else{
+				mailOptions = {
+					to: user.info.email,
+					subject: 'Skybunk Password Reset',
+					text:
+					'You are receiving this because you have requested the reset of the password for your Skybunk account.\n\n'
+					+ 'Please click on the following link, or paste this into your browser to complete the process within two hours of receiving it:\n\n'
+					+ `${url}/users/reset/${user._id}/${token}\n\n`
+					+ `Username: ${user.username}\n\n`
+					+ 'If you did not request this, please ignore this email and your password will remain unchanged.\n',
+				};
+
+				user.resetPasswordExpiration = Date.now() + 2*60*60*1000; //2 hours from now
+			}
+
+			const transporter = nodemailer.createTransport({
+				service:'gmail',
+				auth: config.skybunkEmail
+			});
+
+			user.resetPasswordToken = token;
+
+			user.update(user);
+
+			transporter.sendMail(mailOptions, (err, response) => {
+			if (err) {
+				console.error(err);
+				rej(err);
+			} else {
+				res('Successfully sent email');
+			}
+			});
+		});
+	},
+}

--- a/helpers/passwordReset.js
+++ b/helpers/passwordReset.js
@@ -17,7 +17,7 @@ module.exports = {
 					to: config.webmasterEmail,
 					subject: `Skybunk Password Reset for ${user.firstName} ${user.lastName}`,
 					text:
-					`You are receiving this because ${user.firstName} ${user.lastName}  has requested the reset of the password for your Skybunk account. `
+					`You are receiving this because ${user.firstName} ${user.lastName} has requested the reset of the password for your Skybunk account. `
 					+ `They do not have a registered email address, so the password reset request must be manually verified.\n\n`
 					+ `Please manually verify ${user.firstName} requested this reset. If they did, forward this email to ${email}\n\n\n`
 					+ '-------------------------\n\n'
@@ -58,7 +58,12 @@ module.exports = {
 				console.error(err);
 				rej(err);
 			} else {
-				res('Successfully sent email');
+				if(user.info.email == undefined || user.info.email == ''){
+					res('An email was sent to webmasters to verify your request');
+				}else{
+					res('An email was sent to the given email');
+				}
+				
 			}
 			});
 		});

--- a/models/User.js
+++ b/models/User.js
@@ -7,6 +7,7 @@ const path = require('path');
 const bcrypt = require('bcryptjs');
 const mongoose = require('mongoose');
 
+const passwordReset = require('../helpers/passwordReset');
 const { Schema } = mongoose;
 const ProfilePicture = mongoose.model('ProfilePicture');
 const Post = mongoose.model('Post');
@@ -50,6 +51,9 @@ const UserSchema = new Schema({
     phone: {
       type: String,
     },
+    email: {
+      type: String,
+    }
   },
   profilePicture: {
     type: Schema.Types.ObjectId,
@@ -81,6 +85,12 @@ const UserSchema = new Schema({
     location: {
       type: String,
     },
+  },
+  resetPasswordToken: {
+    type:String,
+  },
+  resetPasswordExpiration: {
+    type: Date,
   },
 });
 
@@ -177,6 +187,7 @@ UserSchema.methods.changePassword = function (newPassword) {
           reject(err);
         } else {
           this.password = hash;
+          this.resetPasswordExpiration = 0; //expire any password reset tokens
           this.save().then(() => {
             resolve(hash);
           })
@@ -187,6 +198,11 @@ UserSchema.methods.changePassword = function (newPassword) {
       });
     });
   });
+};
+
+// Send a reset email to user
+UserSchema.methods.sendPasswordResetEmail = function (email) {
+  return passwordReset.sendPasswordResetEmail(this, email);
 };
 
 UserSchema.methods.updateProfilePicture = function (newBuffer) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1112,6 +1112,11 @@
         "which": "^1.2.9"
       }
     },
+    "crypto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/crypto/-/crypto-1.0.1.tgz",
+      "integrity": "sha512-VxBKmeNcqQdiUQUW2Tzq0t377b54N2bMtXO/qiLa+6eRRmmC4qT3D4OnTGoT/U6O9aklQ/jTwbOtRMTTY8G0Ig=="
+    },
     "crypto-random-string": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
@@ -3899,9 +3904,9 @@
       "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
     },
     "nodemailer": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.3.0.tgz",
-      "integrity": "sha512-TEHBNBPHv7Ie/0o3HXnb7xrPSSQmH1dXwQKRaMKDBGt/ZN54lvDVujP6hKkO/vjkIYL9rK8kHSG11+G42Nhxuw=="
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.4.2.tgz",
+      "integrity": "sha512-g0n4nH1ONGvqYo1v72uSWvF/MRNnnq1LzmSzXb/6EPF3LFb51akOhgG3K2+aETAsJx90/Q5eFNTntu4vBCwyQQ=="
     },
     "nodemon": {
       "version": "1.19.1",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "agenda": "^2.0.2",
     "bcryptjs": "^2.4.3",
     "body-parser": "^1.18.3",
+    "crypto": "^1.0.1",
     "date-fns": "^1.29.0",
     "expo-server-sdk": "^2.4.0",
     "express": "^4.16.3",
@@ -16,7 +17,7 @@
     "mongoose-paginate": "^5.0.3",
     "multer": "^1.3.1",
     "node-fetch": "^2.3.0",
-    "nodemailer": "^6.3.0",
+    "nodemailer": "^6.4.2",
     "path": "^0.12.7",
     "sharp": "^0.22.1",
     "sinon-mongoose": "^2.2.1"


### PR DESCRIPTION
I'm still developing the front end application (web only), but here are the server changes to review for password reset.

The plan is for the web to send a password request with the following body:
{
url:
firstName:
lastName:
username:
email:
}

The auth server will just forward the request given the URL in the body. The server will search for the user via first and last name, or username (in case someone forgot their username and password). 

If an email address is associated with the account, the server will confirm it matches the given email address and then send out a reset link. If there is no address on file, it will send an email to the webmasters who will manually verify the request (if a school email address is used, they can just verify the email address matches the name of the person requesting it).

The reset link contains the user ID and a reset token. The token expires after 2 hours if an email address is register, and expires after 48 hours if it is going through the webmasters.